### PR TITLE
fix auto slider

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -1,3 +1,14 @@
+// jQuery browser was removed as of jQuery v.1.9.x
+jQuery.browser = {};
+(function () {
+  jQuery.browser.msie = false;
+  jQuery.browser.version = 0;
+  if (navigator.userAgent.match(/MSIE ([0-9]+)\./)) {
+    jQuery.browser.msie = true;
+    jQuery.browser.version = RegExp.$1;
+  }
+})();
+
 $(document).ready(function(){
 
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -1,13 +1,8 @@
 // jQuery browser was removed as of jQuery v.1.9.x
-jQuery.browser = {};
-(function () {
-  jQuery.browser.msie = false;
-  jQuery.browser.version = 0;
-  if (navigator.userAgent.match(/MSIE ([0-9]+)\./)) {
-    jQuery.browser.msie = true;
-    jQuery.browser.version = RegExp.$1;
-  }
-})();
+jQuery.browser = {
+    msie: false,
+    version: 0
+};
 
 $(document).ready(function(){
 

--- a/js/jquery.aviaSlider.js
+++ b/js/jquery.aviaSlider.js
@@ -20,7 +20,7 @@ document.documentElement.className += 'js_active';
 			slides: 'li',				// wich element inside the container should serve as slide
 			animationSpeed: 900,		// animation duration
 			autorotation: true,			// autorotation true or false?
-			autorotationSpeed: 5,		// duration between autorotation switch in Seconds
+			autorotationSpeed: 2,		// duration between autorotation switch in Seconds
 			appendControlls: '',		// element to apply controlls to
 			slideControlls: 'items',	// controlls, yes or no?
 			blockSize: {height: 'full', width:'full'},


### PR DESCRIPTION
- Auto slider does not work since it relies on jQuery.browser which is removed from JQuery starting with version 1.9.x
     - The temporary fix is to set jQuery.browser to false (Long term ideal fix is to move away from avia slider (avia slider is no longer available/maintained) to a modern slider.
- Update auto slider time from 5s -> 2s (requested by Dan)